### PR TITLE
Make LinguaObservableString.CurrentValue public

### DIFF
--- a/src/Irihi.Lingua.Core/LinguaObservableString.cs
+++ b/src/Irihi.Lingua.Core/LinguaObservableString.cs
@@ -28,7 +28,7 @@ public sealed class LinguaObservableString : IObservable<string?>
     /// <summary>
     /// Gets the most recently emitted value.
     /// </summary>
-    internal string? CurrentValue => Volatile.Read(ref _currentValue);
+    public string? CurrentValue => Volatile.Read(ref _currentValue);
 
     /// <summary>
     /// Initializes a new instance of <see cref="LinguaObservableString"/> with the given key and initial value.


### PR DESCRIPTION
Expose CurrentValue as a public property so consumers can read the latest value synchronously without subscribing.